### PR TITLE
mod 'get raw JWT' to support Authorization header

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Add the following to LocalSettings.php, being sure to fill in the proper values 
 wfLoadExtension( 'JWTAuth' );
 $wgJWTAuthAlgorithm = ''; // can be: HS256, RS256, EdDSA
 $wgJWTAuthKey = ''; // Depends on which algorithm you are using
+// For RS256 the key is the JWK in PEM format, extracted from the JWKS at https://yourdomain.com/auth/realms/servername/protocol/openid-connect/certs
 $wgJWTGroupMapping = [
   // one group can map to multiple MediaWiki groups...
   'customgroup1' => [

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "JWTAuth",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "author": [
             "[https://github.com/mywikis MyWikis LLC]"
     ],

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "JWTAuth",
-    "version": "0.1.0",
+    "version": "0.1.2",
     "author": [
             "[https://github.com/mywikis MyWikis LLC]"
     ],

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "JWTAuth",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "author": [
             "[https://github.com/mywikis MyWikis LLC]"
     ],

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "JWTAuth",
-    "version": "0.1.4",
+    "version": "0.1.0",
     "author": [
             "[https://github.com/mywikis MyWikis LLC]"
     ],

--- a/includes/JWTHandler.php
+++ b/includes/JWTHandler.php
@@ -35,7 +35,7 @@ class JWTHandler {
         }
         // Extract the JWT substring after the first 7 characters, which removes the "Bearer:" or "Bearer " prefix.
         // Remove any white space characters from the $rawJWTData string and output as $cleanJWTData.
-        $rawJWTData = str_replace(array('Bearer:', 'Bearer '), '', $rawJWTData);
+        $rawJWTData = str_replace(['Bearer:', 'Bearer '], '', $rawJWTData);
         $cleanJWTData = preg_replace('/\s+/', '', $rawJWTData);
     
         return $cleanJWTData;

--- a/includes/JWTHandler.php
+++ b/includes/JWTHandler.php
@@ -27,17 +27,20 @@ class JWTHandler {
     public function preprocessRawJWTData(
         string $rawJWTData
     ): string {
-        if (!str_starts_with($rawJWTData, 'Bearer:')) {
+        // Checks if the $rawJWTData string starts with the literal strings "Bearer:" or "Bearer ".
+        // If it doesn't start with either, it logs an error message and returns an empty string.
+        if (strpos($rawJWTData, 'Bearer:') !== 0 && strpos($rawJWTData, 'Bearer ') !== 0) {
             $this->logger->debug("Invalid JWT auth, doesn't start with Bearer");
             return '';
         }
-
-        $rawJWTData = substr($rawJWTData, strlen('Bearer:'));
+        // Extract the JWT substring after the first 7 characters, which removes the "Bearer:" or "Bearer " prefix.
+        // Remove any white space characters from the $rawJWTData string and output as $cleanJWTData.
+        $rawJWTData = str_replace(array('Bearer:', 'Bearer '), '', $rawJWTData);
         $cleanJWTData = preg_replace('/\s+/', '', $rawJWTData);
-
+    
         return $cleanJWTData;
     }
-
+    
     /**
      * @returns JWTResponse | string Error message
      */

--- a/includes/JWTLogin.php
+++ b/includes/JWTLogin.php
@@ -75,8 +75,8 @@ class JWTLogin extends UnlistedSpecialPage {
         $request = $this->getContext()->getRequest();
     
         // Get JWT data from Authorization header or POST data
-        if (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
-            $jwtDataRaw = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+        if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
+            $jwtDataRaw = $_SERVER['HTTP_AUTHORIZATION'];
         } else if (isset($_POST[self::JWT_PARAMETER])) {
             $jwtDataRaw = $_POST[self::JWT_PARAMETER];
         } else {

--- a/includes/JWTLogin.php
+++ b/includes/JWTLogin.php
@@ -75,14 +75,13 @@ class JWTLogin extends UnlistedSpecialPage {
         $request = $this->getContext()->getRequest();
     
         // Get JWT data from Authorization header or POST data
-        $jwtDataRaw = '';
-        if (isset($_SERVER['HTTP_AUTHORIZATION']) && strpos($_SERVER['HTTP_AUTHORIZATION'], 'Bearer ') === 0) {
-            // Authorization header is present and contains a JWT
-            $jwtDataRaw = substr($_SERVER['HTTP_AUTHORIZATION'], 7);
+        if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
+            $jwtDataRaw = $_SERVER['HTTP_AUTHORIZATION'];
+        } else if (isset($_POST[self::JWT_PARAMETER])) {
+            $jwtDataRaw = $_POST[self::JWT_PARAMETER];
         } else {
-            // Authorization header is not present, try to get JWT from POST data
-            $jwtDataRaw = isset($_POST[self::JWT_PARAMETER]) ? $_POST[self::JWT_PARAMETER] : '';
-        }
+            $jwtDataRaw = '';
+        }     
     
         // Clean data
         $cleanJWTData = $this->jwtHandler->preprocessRawJWTData($jwtDataRaw);

--- a/includes/JWTLogin.php
+++ b/includes/JWTLogin.php
@@ -75,9 +75,8 @@ class JWTLogin extends UnlistedSpecialPage {
         $request = $this->getContext()->getRequest();
     
         // Get JWT data from Authorization header or POST data
-        $headers = getallheaders();
-        if (isset($headers['Authorization'])) {
-            $jwtDataRaw = $headers['Authorization'];
+        if (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+            $jwtDataRaw = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
         } else if (isset($_POST[self::JWT_PARAMETER])) {
             $jwtDataRaw = $_POST[self::JWT_PARAMETER];
         } else {

--- a/includes/JWTLogin.php
+++ b/includes/JWTLogin.php
@@ -75,8 +75,9 @@ class JWTLogin extends UnlistedSpecialPage {
         $request = $this->getContext()->getRequest();
     
         // Get JWT data from Authorization header or POST data
-        if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
-            $jwtDataRaw = $_SERVER['HTTP_AUTHORIZATION'];
+        $headers = getallheaders();
+        if (isset($headers['Authorization'])) {
+            $jwtDataRaw = $headers['Authorization'];
         } else if (isset($_POST[self::JWT_PARAMETER])) {
             $jwtDataRaw = $_POST[self::JWT_PARAMETER];
         } else {

--- a/includes/JWTLogin.php
+++ b/includes/JWTLogin.php
@@ -77,7 +77,7 @@ class JWTLogin extends UnlistedSpecialPage {
         // Get JWT data from Authorization header or POST data
         if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
             $jwtDataRaw = $_SERVER['HTTP_AUTHORIZATION'];
-        } else if (isset($_POST[self::JWT_PARAMETER])) {
+        } elseif (isset($_POST[self::JWT_PARAMETER])) {
             $jwtDataRaw = $_POST[self::JWT_PARAMETER];
         } else {
             $jwtDataRaw = '';


### PR DESCRIPTION
This modification to JWTLogin allows it to receive JWT data from either the Authorization header or POST data. The new code first checks if the Authorization header is present and if so, extracts the JWT from it. If the header is not present, it checks if the POST data contains a JWT. If a JWT is found in either location, it is used to authenticate the user. 
